### PR TITLE
US 0206 networking and docker

### DIFF
--- a/substrate-node/.dockerignore
+++ b/substrate-node/.dockerignore
@@ -1,0 +1,7 @@
+# literally the only file we DON'T want to ignore is target/debug/siip-node
+*
+!target
+target/*
+!target/debug
+target/debug/*
+!target/debug/siip-node

--- a/substrate-node/Dockerfile
+++ b/substrate-node/Dockerfile
@@ -1,0 +1,16 @@
+# Assumes the application has already been built successfully via "cargo build"
+
+FROM paritytech/ci-linux:f592485d-20210318
+WORKDIR /app
+EXPOSE 9933
+EXPOSE 9944
+EXPOSE 30333
+COPY target/debug/siip-node .
+ENTRYPOINT ["./siip-node", "--unsafe-ws-external", "--unsafe-rpc-external", "--base-path", "/var/siip" ]
+
+# justification of --unsafe-ws-external and --unsafe-rpc-external: These flags tell Substrate to bind
+# the websocket and RPC servers to 0.0.0.0 (i.e. any interface) as opposed to just the localhost interface 127.0.0.1.
+# This is marked as unsafe, because these servers should not be exposed to the web, as outside actors could use them to
+# do nefarious things. However, we use Docker to map these ports on the container to the localhost interface on the host.
+# So the servers are still inaccessible to the web
+# see https://github.com/paritytech/substrate/wiki/Public-RPC for more info

--- a/substrate-node/Makefile
+++ b/substrate-node/Makefile
@@ -1,0 +1,23 @@
+CONTAINER=siip-node
+PROFILE=default
+
+default: build image
+
+all: build image deploy
+
+build:
+	cargo build
+
+clean:
+	cargo clean
+
+image: | build
+	docker build -t $(CONTAINER) .
+
+run: | build
+	target/debug/siip-node --no-mdns --tmp --alice
+
+deploy: | build image
+	docker-compose --profile $(PROFILE) up
+
+.PHONY: all build clean default image run deploy

--- a/substrate-node/docker-compose.yml
+++ b/substrate-node/docker-compose.yml
@@ -1,17 +1,88 @@
-version: "3.2"
+version: "3.8"
+
+# TODO command-line args do NOT (currently) include --no-mdns
+  # This is because Libp2p peer discovery appears to be a delicate art.
+    # There is a bug somewhere, and I suspect it's in libp2p, but it could be in docker as well
+  # With MDNS, discovery is immediate - we don't even need the --bootnodes argument
+  # Without MDNS, it is much less reliable. Alice (the boot node) will accept Bob's connection request, but often waits a loooong time (1-3 minutes)
+    # before responding. By this time, Bob has long since timed out and tried again, and the process repeats until Alice responds in time.
+    # Sometimes this happens in 1-5 minutes; other times, I suspect it could go on forever. I've noticed that the more entropy in the network,
+    # the sooner the gridlock tends to end (sometimes, by pinging 172.20.1.1:30333 via curl, I was able to break the cycle and force a connection).
+    # I'm not entirely sure why this is.
+
+# TODO as this is a development environment, there are lots of security holes in this:
+  # 1. Libp2p networking is done using hard-coded node keys. This allows, among other things, the nodes' peer ID's to be known ahead of time
+  # 2. Nodes are using the well-known keys for alice, bob, etc. (Currently, this is actually expected by the mining agents; see service.rs)
+
+# TODO debug support will become important - look at LLDB for remote debugging.
+  # (Note that this requires a debug server on the target container, and thus possibly a task manager, so this may be nontrivial)
 
 services:
-  dev:
-    container_name: node-template
-    image: paritytech/ci-linux:974ba3ac-20201006
-    working_dir: /var/www/node-template
+  alice:
+    image: siip-node
     ports:
-      - "9944:9944"
-    environment:
-      - CARGO_HOME=/var/www/node-template/.cargo
-    volumes:
-      - .:/var/www/node-template
-      - type: bind
-        source: ./.local
-        target: /root/.local
-    command: bash -c "cargo build --release && ./target/release/node-template --dev --ws-external"
+      - "127.0.0.1:9944:9944"
+      - "127.0.0.1:9933:9933"
+      - "127.0.0.1:30333:30333"
+    tmpfs: /var/siip
+    networks:
+      siip_network:
+        ipv4_address: 172.20.1.2
+    command: 
+      - "--alice"
+      - "--validator" # technically implied by --alice; included for completeness
+      - "--node-key"
+      - "0000000000000000000000000000000000000000000000000000000000000001"
+
+  bob:
+    image: siip-node
+    ports:
+      - "127.0.0.1:9945:9944"
+      - "127.0.0.1:9934:9933"
+      - "127.0.0.1:30334:30333"
+    tmpfs: /var/siip
+    networks:
+      siip_network:
+        ipv4_address: 172.20.1.3
+    command:
+      - "--bob"
+      - "--validator" # technically implied by --bob; included for completeness
+      - "--rpc-cors"
+      - "all" # CORS validation doesn't work for RPC server because Substrate expects a Host header of localhost:9944 insteasd of localhost:9945
+      - "--node-key"
+      - "0000000000000000000000000000000000000000000000000000000000000002"
+      - "--bootnodes"
+      - "/ip4/172.20.1.2/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp" # alice
+    profiles:
+      - basic-network
+      - complex-network
+    depends_on:
+      - alice
+
+  observer:
+    image: siip-node
+    ports:
+      - "127.0.0.1:9946:9944"
+      - "127.0.0.1:9935:9933"
+      - "127.0.0.1:30335:30333"
+    tmpfs: /var/siip
+    networks:
+      siip_network:
+        ipv4_address: 172.20.1.4
+    command:
+      - "--rpc-cors"
+      - "all" # CORS validation doesn't work for RPC server because Substrate expects a Host header of localhost:9944 insteasd of localhost:9946
+      - "--bootnodes"
+      - "/ip4/172.20.1.3/tcp/30333/p2p/12D3KooWHdiAxVd8uMQR1hGWXccidmfCwLqcMpGwR6QcTP6QRMuD" # bob
+    profiles:
+      - complex-network
+    depends_on:
+      - alice
+      - bob
+
+networks:
+  siip_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.1.0/24

--- a/substrate-node/network-test.py
+++ b/substrate-node/network-test.py
@@ -1,0 +1,230 @@
+#!/usr/bin/python3
+
+import math
+import os
+import subprocess
+import sys
+import time
+import uuid
+
+import substrateinterface
+from substrateinterface import SubstrateInterface
+from substrateinterface import Keypair
+
+##########################################################################################
+############################## Configuration Constants ##################################
+##########################################################################################
+
+# hash rate in hashes per second, for one node. Determined experimentally - will vary by machine
+HASH_RATE = 24500
+# average number of hashes that a node must try before winning the lottery
+DIFFICULTY = 1_000_000
+# probability of timing out and assuming the network will never produce a new block
+ALPHA = 0.05
+
+# Block production follows exponential distribution with parameter lambda = HASH_RATE/DIFFICULTY
+LAMBDA = HASH_RATE / DIFFICULTY
+# If random variable T represents time to produce a block, then `Pr[T > x] = e^{-LAMBDA*x}`
+# We want this probability to equal ALPHA, so
+# `ALPHA = e^{-LAMBDA*x}`, which simplifies to `x = ln(ALPHA)/-LAMBDA`
+BLOCK_TIMEOUT = math.log(ALPHA) / -LAMBDA + 1
+
+COLOR_SUCCESS = '\033[32;1m'    # green, bold
+COLOR_HIGHLIGHT = '\033[36;1m'  # turquoise, bold
+COLOR_RESET = '\033[0m'
+
+ALICE_ACCOUNT_ID = Keypair.create_from_uri('//Alice').ss58_address
+BOB_ACCOUNT_ID = Keypair.create_from_uri('//Bob').ss58_address
+CHARLIE_KEY = Keypair.create_from_uri('//Charlie')
+
+
+##########################################################################################
+############################## Helper Functions and Classes ##############################
+##########################################################################################
+class TimeoutError(Exception):
+    pass
+
+class Timer:
+    def __init__(self, timeout):
+        self.timeout = timeout
+    def __enter__(self):
+        self.start_time = time.time()
+        return self
+    def check(self):
+        if self.start_time + self.timeout < time.time():
+            raise TimeoutError('Operation took more than %.1f seconds'%(self.timeout))
+    def __exit__(self, _exc_type, _exc_value, _traceback):
+        pass
+
+def assert_consensus(alice, bob, domains):
+    alice_num_blocks = alice.query('System', 'Number')
+    alice_num_blocks = alice_num_blocks.value if alice_num_blocks is not None else 0
+    bob_num_blocks = bob.query('System', 'Number')
+    bob_num_blocks = bob_num_blocks.value if bob_num_blocks is not None else 0
+    assert alice_num_blocks == bob_num_blocks, f'Blockchains out of sync: Alice has {alice_num_blocks} blocks but Bob has {bob_num_blocks}'
+
+    for i in range(alice_num_blocks):
+        alice_hash = alice.query('System', 'BlockHash', params=[i]).value
+        bob_hash = bob.query('System', 'BlockHash', params=[i]).value
+        assert alice_hash == bob_hash, f'Blockchains out of sync at block {i}: Alice has {alice_hash}, but Bob has {bob_hash}'
+
+    for d in domains:
+        alice_certificate = alice.query('SiipModule', 'CertificateMap', params=[d])
+        bob_certificate = bob.query('SiipModule', 'CertificateMap', params=[d])
+        assert (alice_certificate is None and bob_certificate is None) or \
+                (alice_certificate is not None and bob_certificate is not None and alice_certificate.value == bob_certificate.value), \
+                f'Blockchains out of sync at certificate {d}: Alice has {alice_certificate}, but Bob has {bob_certificate}'
+
+    alice_own_balance = alice.query('System', 'Account', params=[ALICE_ACCOUNT_ID]).value['data']['free']
+    bob_own_balance = bob.query('System', 'Account', params=[BOB_ACCOUNT_ID]).value['data']['free']
+    alice_bobs_balance = alice.query('System', 'Account', params=[BOB_ACCOUNT_ID]).value['data']['free']
+    bob_alices_balance = bob.query('System', 'Account', params=[ALICE_ACCOUNT_ID]).value['data']['free']
+
+    assert alice_own_balance == bob_alices_balance, f'Blockchains are out of sync: Alice claims she has {alice_own_balance} coins, but Bob says she has {bob_alices_balance}'
+    assert bob_own_balance == alice_bobs_balance, f'Blockchains are out of sync: Bob claims she has {bob_own_balance} coins, but Alice says he has {alice_bobs_balance}'
+
+def siip_node_connect(port = 9933):
+    return SubstrateInterface(
+        url=f"http://127.0.0.1:{port}",
+        ss58_format=42,
+        type_registry_preset='polkadot', 
+        type_registry={
+            "types": {
+                "Certificate": {
+                    "type": "struct",
+                    "type_mapping": [
+                        ["version_number", "i32"],
+                        ["owner_id", "AccountId"],
+                        ["name", "Vec<u8>"],
+                        ["info", "Vec<u8>"],
+                        ["key", "Vec<u8>"],
+                        ["ip_addr", "Vec<u8>"],
+                        ["domain", "Vec<u8>"]
+                    ]
+                }
+            }
+        }
+    )
+
+# register the given domain, and block until it's successfully added to the blockchain.
+# It's up to the user to make sure the domain does not already exist
+def register_and_wait(substrate, domain):
+    call = substrate.compose_call(
+        call_module='SiipModule',
+        call_function='register_certificate',
+        call_params={
+            'name': 'John Smith',
+            'domain': domain,
+            'ip_addr': '10.0.0.1',
+            'info': '{}',
+            'key': '01:23:45:67:89:AB:CD:EF',
+        }
+    )
+    # This test setup uses Charlie to register all domains
+    extrinsic = substrate.create_signed_extrinsic(call=call, keypair=CHARLIE_KEY)
+    substrate.submit_extrinsic(extrinsic)
+    
+    # Note that I think with a websocket connection, you could use 
+    # substrate.submit_extrinsic(extrinsic, wait_for_inclusion = True)
+    # to block until the extrinsic is included, and eliminate the below code.
+    # But websocket support in substrate-interface appears to be unstable, so that's a no go for now
+    with Timer(BLOCK_TIMEOUT * 2) as timer: # * 2 is because sometimes it can take up to two blocks for a transaction to get added
+        certificate = substrate.query('SiipModule', 'CertificateMap', params=[domain])
+        while certificate is None:
+            timer.check()
+            time.sleep(1)
+            certificate = substrate.query('SiipModule', 'CertificateMap', params=[domain])
+    return domain
+
+##########################################################################################
+############################## Test Code #################################################
+##########################################################################################
+start_time = time.time()
+
+print(f'{COLOR_HIGHLIGHT}Shutting down existing network to prepare for test:{COLOR_RESET}')
+print('$ docker-compose down')
+subprocess.run('docker-compose down'.split(), check=True)
+
+print()
+
+print(f'{COLOR_HIGHLIGHT}Starting alice node:{COLOR_RESET}')
+print('$ docker-compose up --detach alice')
+subprocess.run('docker-compose up --detach alice'.split(), check=True)
+
+print()
+
+# wait for alice to start up
+time.sleep(10)
+
+alice = siip_node_connect(9933)
+
+
+#alice_start_balance = alice.query('System', 'Account', params=[ALICE_ACCOUNT_ID]).value['data']['free']
+#bob_start_balance = alice.query('System', 'Account', params=[BOB_ACCOUNT_ID]).value['data']['free']
+
+domain = f'{uuid.uuid4()}.com'
+print(f'{COLOR_HIGHLIGHT}Registering {domain}... {COLOR_RESET}')
+register_and_wait(alice, domain)
+
+print()
+
+print(f'{COLOR_HIGHLIGHT}Starting bob node:{COLOR_RESET}')
+print('$ docker-compose up --detach bob')
+subprocess.run('docker-compose up --detach bob'.split(), check=True)
+
+# wait for bob to start up
+time.sleep(10)
+
+bob = siip_node_connect(9934)
+
+print()
+
+print(f'{COLOR_HIGHLIGHT}Cross-checking alice and bob for consistency: {COLOR_RESET}', end='')
+assert_consensus(alice, bob, [domain])
+print('ok')
+
+print()
+
+print(f'{COLOR_HIGHLIGHT}Now verifying that alice and bob both receive transactions and mine blocks:{COLOR_RESET}')
+alice_balance = alice.query('System', 'Account', params=[ALICE_ACCOUNT_ID]).value['data']['free']
+alice_has_mined = False
+
+bob_balance = alice.query('System', 'Account', params=[BOB_ACCOUNT_ID]).value['data']['free']
+bob_has_mined = False
+tries = 0
+domains = [domain]
+while not alice_has_mined or not bob_has_mined:
+    tries += 1
+    assert tries <= 10, "Either Alice or Bob is mining all the blocks. This indicates transactions are probably not being gossipped properly"
+
+    domain = f'{uuid.uuid4()}.com'
+    print(f'Registering {domain}... ', end='', flush=True)
+    register_and_wait(alice, domain)
+    alice_new_balance = alice.query('System', 'Account', params=[ALICE_ACCOUNT_ID]).value['data']['free']
+    bob_new_balance = alice.query('System', 'Account', params=[BOB_ACCOUNT_ID]).value['data']['free']
+
+    # either Alice or Bob should've mined the transaction, and their balance should increase as a result
+    assert alice_balance == alice_new_balance or bob_balance == bob_new_balance
+    assert alice_balance != alice_new_balance or bob_balance != bob_new_balance
+
+    if alice_balance != alice_new_balance:
+        alice_has_mined = True
+        alice_balance = alice_new_balance
+        print('Mined by Alice')
+    else:
+        bob_has_mined = True
+        bob_balance = bob_new_balance
+        print('Mined by Bob')
+
+    domains.append(domain)
+    assert_consensus(alice, bob, domains)
+
+print()
+
+print(f'{COLOR_HIGHLIGHT}Shutting down the network:{COLOR_RESET}')
+print('$ docker-compose down')
+subprocess.run('docker-compose down'.split(), check=True)
+
+print()
+
+print(f'{COLOR_SUCCESS}Success!{COLOR_RESET} Integration test passed in {time.time() - start_time} seconds')


### PR DESCRIPTION
Contains docker configuration, and an integration test of Substrate's built-in networking functionality.

docker-compose automates starting and stopping the network. Once the project has been built and a Docker image has been generated, you can just run `docker-compose up` to start. To run two nodes, use `docker-compose --profile basic-network up`.

Requires installation of docker, docker-compose, and substrate-interface. To install:
- docker: follow the directions on https://docs.docker.com/get-docker/
- docker-compose: run `sudo curl -L "https://github.com/docker/compose/releases/download/1.28.6/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && sudo chmod 755 /usr/local/bin/docker-compose`
- substrate-interface: run `pip install substrate-interface`. (Required if you want to run network-test.py)