### PR TITLE
sip.sh public key validation compatibility fix

### DIFF
--- a/client/sip.sh
+++ b/client/sip.sh
@@ -7,7 +7,7 @@
 
 domain=$1
 ip=$(dig $domain +short | head -n1)
-pubkey=$(echo | openssl s_client -connect $domain:443 2>/dev/null | openssl x509 -pubkey -noout | head -n -1 | tail -n +2 | tr -d '\n' | base64 -d | od -t x1 -An | tr -d ' ' | tr -d '\n')
+pubkey=$(echo | openssl s_client -connect $domain:443 2>/dev/null | openssl x509 -pubkey -noout | head -n -1 | tail -n +2 | tr -d '\n' | base64 -d | od -t x1 -An | tr -d ' ' | tr -d '\n' | tr [:lower:] [:upper:] | sed 's/.\{2\}/&:/g;s/:$//' )
 
 echo "$domain $ip $pubkey"
 ./register.py $domain 'sip' $ip '{}' $pubkey


### PR DESCRIPTION
This makes sip.sh work with the strict validation on public keys. I'm not sure if we really need/want to keep requiring colon separators and only capital letters for hex though. 

(If this were going into production we should at the very least remove the colon separators from public keys before storing them, even if we wanted to keep requiring the colons in inputs. No need to store strings where 1/3 of the string can be inferred.)