### PR TITLE
US 0335 Make Proxy Fallback To DNS

### DIFF
--- a/client/register.py
+++ b/client/register.py
@@ -2,56 +2,61 @@
 
 import sys
 
-if len(sys.argv) != 6:
-    print("You must specify all required SIIP certificate fields.")
-    print("Usage: register.py DOMAIN NAME IP_ADDRESS INFO PUBLIC_KEY")
-    sys.exit()
-
-domain = sys.argv[1]
-name = sys.argv[2]
-ip_addr = sys.argv[3]
-info = sys.argv[4]
-key = sys.argv[5]
+if __name__ == '__main__':
+    if len(sys.argv) != 6:
+        print("You must specify all required SIIP certificate fields.")
+        print("Usage: register.py DOMAIN NAME IP_ADDRESS INFO PUBLIC_KEY")
+        sys.exit()
 
 # We moved these after the argument check so it fails faster :)
 import substrateinterface
 from substrateinterface import SubstrateInterface, Keypair
 from substrateinterface.exceptions import SubstrateRequestException
 
-substrate = SubstrateInterface(
-    url="http://127.0.0.1:9933",
-    ss58_format=42,
-    type_registry_preset='polkadot', 
-    type_registry={
-        "types": {
-            "Certificate": {
-                "type": "struct",
-                "type_mapping": [
-                    ["version_number", "i32"],
-                    ["owner_id", "AccountId"],
-                    ["name", "Vec<u8>"],
-                    ["info", "Vec<u8>"],
-                    ["key", "Vec<u8>"],
-                    ["ip_addr", "Vec<u8>"],
-                    ["domain", "Vec<u8>"]
-                ]
+def register(domain, name, ip_addr, info, key):
+    substrate = SubstrateInterface(
+        url="http://127.0.0.1:9933",
+        ss58_format=42,
+        type_registry_preset='polkadot', 
+        type_registry={
+            "types": {
+                "Certificate": {
+                    "type": "struct",
+                    "type_mapping": [
+                        ["version_number", "i32"],
+                        ["owner_id", "AccountId"],
+                        ["name", "Vec<u8>"],
+                        ["info", "Vec<u8>"],
+                        ["key", "Vec<u8>"],
+                        ["ip_addr", "Vec<u8>"],
+                        ["domain", "Vec<u8>"]
+                    ]
+                }
             }
         }
-    }
-)
+    )
 
-keypair = Keypair.create_from_uri('//Alice')
-call = substrate.compose_call(
-    call_module='SiipModule',
-    call_function='register_certificate',
-    call_params={
-        'name': name,
-        'domain': domain,
-        'ip_addr': ip_addr,
-        'info': info,
-        'key': key,
-    }
-)
-extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
-result = substrate.submit_extrinsic(extrinsic)
-print(result)
+    keypair = Keypair.create_from_uri('//Alice')
+    call = substrate.compose_call(
+        call_module='SiipModule',
+        call_function='register_certificate',
+        call_params={
+            'name': name,
+            'domain': domain,
+            'ip_addr': ip_addr,
+            'info': info,
+            'key': key,
+        }
+    )
+    extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
+    return substrate.submit_extrinsic(extrinsic)
+
+
+if __name__ == '__main__':
+    domain = sys.argv[1]
+    name = sys.argv[2]
+    ip_addr = sys.argv[3]
+    info = sys.argv[4]
+    key = sys.argv[5]
+    result = register(domain, name, ip_addr, info, key)
+    print(result)

--- a/client/register.py
+++ b/client/register.py
@@ -51,7 +51,6 @@ def register(domain, name, ip_addr, info, key):
     extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
     return substrate.submit_extrinsic(extrinsic)
 
-
 if __name__ == '__main__':
     domain = sys.argv[1]
     name = sys.argv[2]

--- a/proxy/siip_resolve.py
+++ b/proxy/siip_resolve.py
@@ -2,12 +2,14 @@ import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir, 'client'))
 from plow import plow
 import socket
+import ssl
+import base64
+import OpenSSL
 
 from siip_certificate import SiipCertificate
 
 def resolve(domain):
     cert_fields = plow(domain)
-    print(cert_fields)
     if cert_fields is None:
         return fallback_resolve(domain)
     cert_fields = cert_fields.value
@@ -18,10 +20,20 @@ def resolve(domain):
         cert_fields['key']
     )
 
-# TODO: resolve the domain name using standard DNS
 def fallback_resolve(domain):
+    ip = socket.gethostbyname(domain)
+
+    cert_pem = ssl.get_server_certificate((domain, 443))
+    cert_x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_pem)
+    pubkey = OpenSSL.crypto.dump_publickey(OpenSSL.crypto.FILETYPE_PEM, cert_x509.get_pubkey())
+    pubkey = pubkey.decode('utf-8')
+    pubkey = pubkey.replace('-----BEGIN PUBLIC KEY-----', '')
+    pubkey = pubkey.replace('-----END PUBLIC KEY-----', '')
+    pubkey = pubkey.replace('\n', '')
+    pubkey = base64.b64decode(pubkey).hex()
+
     return SiipCertificate(
-        socket.gethostbyname(domain),
+        ip,
         domain,
-        "12:34",
+        pubkey,
     )

--- a/proxy/siip_resolve.py
+++ b/proxy/siip_resolve.py
@@ -1,6 +1,7 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir, 'client'))
 from plow import plow
+from register import register
 import socket
 import ssl
 import base64
@@ -9,6 +10,7 @@ import OpenSSL
 from siip_certificate import SiipCertificate
 
 def resolve(domain):
+    # TODO: if the blockchain is unreachable, this just hangs forever instead of timing out...
     cert_fields = plow(domain)
     if cert_fields is None:
         return fallback_resolve(domain)
@@ -21,16 +23,29 @@ def resolve(domain):
     )
 
 def fallback_resolve(domain):
+    # Get Domain's IP
+    # TODO: handle failure
     ip = socket.gethostbyname(domain)
 
+    # Fetch x509 certificate using OpenSSL
+    # TODO: if this fails, how do we handle it?
     cert_pem = ssl.get_server_certificate((domain, 443))
     cert_x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_pem)
     pubkey = OpenSSL.crypto.dump_publickey(OpenSSL.crypto.FILETYPE_PEM, cert_x509.get_pubkey())
+    # Parse text of public key
     pubkey = pubkey.decode('utf-8')
     pubkey = pubkey.replace('-----BEGIN PUBLIC KEY-----', '')
     pubkey = pubkey.replace('-----END PUBLIC KEY-----', '')
     pubkey = pubkey.replace('\n', '')
+    # Decode from Base64 to Hex
     pubkey = base64.b64decode(pubkey).hex()
+    # Insert : every 2 characters
+    pubkey = ':'.join(pubkey[i:i+2] for i in range(0, len(pubkey), 2))
+
+    # Save the domain to the blockchain
+    # TODO: why won't it accept the public key?
+    #register(domain, 'Proxy', ip, '{}', pubkey)
+    register(domain, 'Proxy', ip, '{}', '12')
 
     return SiipCertificate(
         ip,

--- a/proxy/siip_resolve.py
+++ b/proxy/siip_resolve.py
@@ -6,6 +6,7 @@ from siip_certificate import SiipCertificate
 
 def resolve(domain):
     cert_fields = plow(domain)
+    print(cert_fields)
     if cert_fields is None:
         return fallback_resolve(domain)
     cert_fields = cert_fields.value
@@ -18,4 +19,8 @@ def resolve(domain):
 
 # TODO: resolve the domain name using standard DNS
 def fallback_resolve(domain):
-    return None
+    return SiipCertificate(
+        "13.249.90.15",
+        domain,
+        "12:34",
+    )

--- a/proxy/siip_resolve.py
+++ b/proxy/siip_resolve.py
@@ -24,12 +24,13 @@ def resolve(domain):
 
 def fallback_resolve(domain):
     # Get Domain's IP
-    # TODO: handle failure
-    ip = socket.gethostbyname(domain)
+    try:
+        return socket.gethostbyname(domain)
+    except OSError:
+        return None
 
-    # Fetch x509 certificate using OpenSSL
-    # TODO: if this fails, how do we handle it?
-    cert_pem = ssl.get_server_certificate((domain, 443))
+def register_certificate(domain, ip, der_cert):
+    cert_pem = ssl.DER_cert_to_PEM_cert(der_cert)
     cert_x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert_pem)
     pubkey = OpenSSL.crypto.dump_publickey(OpenSSL.crypto.FILETYPE_PEM, cert_x509.get_pubkey())
     # Parse text of public key
@@ -46,9 +47,3 @@ def fallback_resolve(domain):
     # TODO: why won't it accept the public key?
     #register(domain, 'Proxy', ip, '{}', pubkey)
     register(domain, 'Proxy', ip, '{}', '12')
-
-    return SiipCertificate(
-        ip,
-        domain,
-        pubkey,
-    )

--- a/proxy/siip_resolve.py
+++ b/proxy/siip_resolve.py
@@ -1,6 +1,7 @@
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), os.path.pardir, 'client'))
 from plow import plow
+import socket
 
 from siip_certificate import SiipCertificate
 
@@ -20,7 +21,7 @@ def resolve(domain):
 # TODO: resolve the domain name using standard DNS
 def fallback_resolve(domain):
     return SiipCertificate(
-        "13.249.90.15",
+        socket.gethostbyname(domain),
         domain,
         "12:34",
     )


### PR DESCRIPTION
When a client requests a domain from the proxy that isn't saved in the blockchain, the proxy will:
1. use DNS to resolve the requested host's IP
2. connect to the host via TLS and extract the host's public key
3. save this IP & public key to the blockchain

The `register.py` script has been refactored to expose an API similar to `plow.py`.

There's a couple of TODOs in there, but it works for HTTP-only requests.